### PR TITLE
PHPUnit

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,57 @@
+## Background
+- **Jasmine** is a behavior-driven development framework for testing JavaScript code.
+- **Karma** is a test runner that knows how to execute tests written in Jasmine and report results.
+- **PHPUnit** is a unit testing framework for the PHP programming language. 
+
+## Karma & Jasmine Setup
+1. Ensure you have [Node.js](https://nodejs.org/en/) installed.
+2. Install Jasmine </br>
+ `$ npm install --save-dev jasmine`
+3. Install Karma </br>
+ `$ npm install --save-dev karma`
+4. Install Karma browser dependencies </br>
+ `$ npm install --save-dev karma-jasmine karma-chrome-launcher`
+ `$ npm install --save-dev karma-jasmine karma-firefox-launcher`
+ 5. Check that you actually have Karma & Jasmine installed
+	```
+	$ karma --version
+	Karma version: 2.0.0
+
+	$ npm jasmine --version
+	5.6.0
+	```
+## Running Jasmine Tests with Karma
+From the repo folder:
+1. `$ cd/test`
+2. To run all test suites </br>
+`$ karma start --single-run`
+
+## PHPUnit Setup
+1. Ensure you have the latest stable [PHP release](http://windows.php.net/download/) downloaded and added to your `PATH` variable.
+2. Download the [PHAR](https://phar.phpunit.de/phpunit-6.5.phar) and save the file as *phpunit.phar* in a desired directory.
+3. Add that directory to your `PATH`.
+4. Exit your CLI (Terminal, Windows Command Prompt, etc.) and start a new instance.
+5. Check that you have PHP and PHPUnit installed. You should see a similar output below.
+```
+$ php -v
+PHP 7.2.2 (cli) (built: Jan 31 2018 19:31:17) ( ZTS MSVC15 (Visual C++ 2017) x64 )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
+
+$ phpunit --version
+PHPUnit 6.5.6 by Sebastian Bergmann and contributors.
+```
+You may want to check the [PHPUnit installation manual](https://phpunit.de/manual/current/en/installation.html) to get specific setup for your OS.
+
+## Running PHPUnit Tests
+From the repo folder:
+1. `$ cd/test`
+2. To run all test suites </br>
+`$ phpunit --configuration="phpunit.xml"`
+
+### Reports
+Reports for all Jasmine and PHPUnit tests will be generated in the `test/reports` directory. </br>
+ 
+## Resources
+- [Introduction to Writing Jasmine Tests](https://jasmine.github.io/edge/introduction.html)
+- [PHPUnit Manual](https://phpunit.de/manual/current/en/index.html)

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,5 @@
+# Unit Tests - Karma, Jasmine, PHPUnit
+
 ## Background
 - **Jasmine** is a behavior-driven development framework for testing JavaScript code.
 - **Karma** is a test runner that knows how to execute tests written in Jasmine and report results.

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function(config) {
   config.set({
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
+    basePath: '.',
 
 
     // frameworks to use
@@ -14,8 +14,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'www/js/*.js',
-      'test/js/*.js'
+      '../www/js/*.js',
+      'js/*.js'
     ],
 
 
@@ -26,7 +26,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-		'www/js/*.js':'coverage'
+		'../www/js/*.js':'coverage'
     },
 	
 		
@@ -38,17 +38,17 @@ module.exports = function(config) {
 	
 	// coverage reporter options
 	coverageReporter: {
-		dir: 'test/reports',
+		dir: 'reports',
 		reporters: [
 			// specify html report
-			{ type: 'html', subdir: 'code_coverage' }
+			{ type: 'html', subdir: 'karma_coverage' }
 		]
 	},
 	
 	
 	// html reporter options
 	htmlReporter: {
-		outputFile: 'test/reports/test_run_results.html',
+		outputFile: 'reports/karma_run_results.html',
 		pageTitle: 'Karma/Jasmine Unit Test Run Results',
 		groupSuites: true
     },

--- a/test/php/DummyTest.php
+++ b/test/php/DummyTest.php
@@ -1,0 +1,14 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class DummyTest extends TestCase
+{
+    /**
+     * @test
+     * A dummy test
+     */
+    public function testTestCase()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit 
+	colors="true"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	stopOnSkipped="false"
+>
+	<testsuites>
+		<testsuite name="Dummy Suite">
+		<directory>php</directory>
+		</testsuite>
+	</testsuites>
+	<logging>
+		<log type="testdox-html" target="reports/phpunit_runs.html"/>
+	</logging>
+</phpunit>


### PR DESCRIPTION
Added PHPUnit setup and dummy test cases. The dummy test case ids intended for devs to run locally to ensure they have properly setup PHPUnit. Afterwards, such test can be removed/replaced with actual test cases.